### PR TITLE
Add simple drag-and-drop Kanban board

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kanban Board</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <h1>Kanban Board</h1>
+    <div class="controls">
+        <input type="text" id="task-input" placeholder="New task" />
+        <button id="add-task">Add Task</button>
+    </div>
+    <div id="board">
+        <div class="column" id="todo">
+            <h2>To Do</h2>
+        </div>
+        <div class="column" id="in-progress">
+            <h2>In Progress</h2>
+        </div>
+        <div class="column" id="done">
+            <h2>Done</h2>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,60 @@
+const addBtn = document.getElementById('add-task');
+const input = document.getElementById('task-input');
+const columns = document.querySelectorAll('.column');
+
+addBtn.addEventListener('click', () => {
+    const text = input.value.trim();
+    if (!text) return;
+    const task = createTaskElement(text);
+    document.getElementById('todo').appendChild(task);
+    input.value = '';
+});
+
+function createTaskElement(text) {
+    const task = document.createElement('div');
+    task.className = 'task';
+    task.draggable = true;
+
+    const span = document.createElement('span');
+    span.textContent = text;
+
+    const delBtn = document.createElement('button');
+    delBtn.textContent = '✕';
+    delBtn.className = 'delete-btn';
+    delBtn.addEventListener('click', () => task.remove());
+
+    task.appendChild(span);
+    task.appendChild(delBtn);
+
+    task.addEventListener('dragstart', () => {
+        task.classList.add('dragging');
+    });
+
+    task.addEventListener('dragend', () => {
+        task.classList.remove('dragging');
+    });
+
+    return task;
+}
+
+columns.forEach(column => {
+    column.addEventListener('dragover', e => {
+        e.preventDefault();
+    });
+
+    column.addEventListener('dragenter', e => {
+        e.preventDefault();
+        column.classList.add('over');
+    });
+
+    column.addEventListener('dragleave', () => {
+        column.classList.remove('over');
+    });
+
+    column.addEventListener('drop', e => {
+        e.preventDefault();
+        const task = document.querySelector('.task.dragging');
+        if (task) column.appendChild(task);
+        column.classList.remove('over');
+    });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,65 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background: #f0f0f0;
+}
+
+h1 {
+    text-align: center;
+}
+
+.controls {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 20px;
+}
+
+#task-input {
+    width: 200px;
+    padding: 5px;
+    margin-right: 10px;
+}
+
+#board {
+    display: flex;
+    justify-content: space-around;
+}
+
+.column {
+    background: #fff;
+    padding: 10px;
+    border-radius: 5px;
+    width: 30%;
+    min-height: 300px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.column h2 {
+    text-align: center;
+}
+
+.task {
+    background: #e0e0e0;
+    margin: 10px 0;
+    padding: 10px;
+    border-radius: 5px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.task.dragging {
+    opacity: 0.5;
+}
+
+.delete-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: #c00;
+}
+
+.column.over {
+    background: #e8f0fe;
+}


### PR DESCRIPTION
## Summary
- add basic HTML/CSS/JS files implementing a Kanban board with To Do, In Progress and Done columns
- allow adding, deleting and drag-and-drop rearranging of tasks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac55da35908328832070eac3c11375